### PR TITLE
update install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,6 @@ install:
     - conda env create --file environment.yml
     - source activate cta-benchmarks
 
-script:
-    - python build.py
-
 after_script:
     - source deactivate
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,4 @@ dependencies:
   - jupyter
   - papermill
   - seaborn
-  - pandas
-  - pip:
-      - eventio==0.11.0  # until this moves to conda...con
+  - nbstripout


### PR DESCRIPTION
Hi @kosack

- I think pyeventio is now installed as a conda package with ctapipe, so I removed it from the `environment.yml`
- I added `nbstripout` which seems to be exactly what we want for the notebooks.
- I removed the `build.py` from Travis. This point I want to discuss. Up to me, we should unit test with Travis the library that comes with cta-benchmarks (as well as the install). However, we should obviously not run the build here. Then the benchmarks will be runned with Jenkins on the CC. I hope we can configure Jenkins to run build.py then - and not with the `.travis.yml` config. Do you agree?

More PR will follow.